### PR TITLE
Update example code based on reviewer feedback

### DIFF
--- a/examples/graph-coloring/gc-states.scm
+++ b/examples/graph-coloring/gc-states.scm
@@ -51,7 +51,7 @@
 
 ; % One node can't take more than one color. (Upper bound)
 ; :- assign(N, C1), assign(N, C2), C1 != C2.
-(constrainto ((assign n1 c1) (assign n2 c2)) ((eq? n1 n2)))
+(constrainto ((assign n1 c1) (assign n2 c2)) ((eq? n1 n2) (not (eq? c1 c2))))
 
 ; % One node must take one color. (Lower bound)
 ; :- not assign(N, r), not assign(N, g), not assign(N, b), node(N).
@@ -70,9 +70,13 @@
 ; :- edge(N, M), assign(N, C), assign(M, C).
 (constrainto ((neighbors x y) (assign n1 c1) (assign n2 c2)) ((eq? x n1) (eq? y n2) (eq? c1 c2)))
 
-; % Top-down solver rules.
+; Solver specified rules (Not stable model semantics)
+; % Top-down solver rules, this is an engineering hack, not stable model
+; semantics. Other bottom-up solver won't produce the right answer.
 ; % Solving heuristic, node ordering.
+; :- assign(N1, C1), assign(N2, C2), N1 > N2.
 (constrainto ((assign n1 c1) (assign n2 c2)) ((> (symbol-hash n1) (symbol-hash n2))))
 
 ; % Remove duplicated answers in top-down query.
-; (constrainto ((assign n1 c1) (assign n2 c2)) ((eq? n1 n2) (eq? c1 c2)))
+; :- assign(N1, C1), assign(N2, C2), N1 = N2, C1 = C2.
+(constrainto ((assign n1 c1) (assign n2 c2)) ((eq? n1 n2) (eq? c1 c2)))

--- a/examples/graph-coloring/gc.scm
+++ b/examples/graph-coloring/gc.scm
@@ -55,10 +55,7 @@
 
 ; % One node can't take more than one color. (Upper bound)
 ; :- assign(N, C1), assign(N, C2), C1 != C2.
-; % Remove duplicated answers in top-down query.
-; (constrainto ((assign n1 c1) (assign n2 c2)) ((= n1 n2) (eq? c1 c2)))
-; So they combined as one rule.
-(constrainto ((assign n1 c1) (assign n2 c2)) ((= n1 n2)))
+(constrainto ((assign n1 c1) (assign n2 c2)) ((= n1 n2) (not (eq? c1 c2))))
 
 ; % One node must take one color. (Lower bound)
 ; :- not assign(N, r), not assign(N, g), not assign(N, b), node(N).
@@ -77,7 +74,13 @@
 ; :- edge(N, M), assign(N, C), assign(M, C).
 (constrainto ((neighbors x y) (assign n1 c1) (assign n2 c2)) ((= x n1) (= y n2) (eq? c1 c2)))
 
-; % Top-down solver rules.
+; Solver specified rules (Not stable model semantics)
+; % Top-down solver rules, this is an engineering hack, not stable model
+; semantics. Other bottom-up solver won't produce the right answer.
 ; % Solving heuristic, node ordering.
-(constrainto ((assign n1 c1) (assign n2 c2)) ((> n1 n2)))
+; (constrainto ((assign n1 c1) (assign n2 c2)) ((> n1 n2)))
 
+; % Remove duplicated answers in top-down query.
+; (constrainto ((assign n1 c1) (assign n2 c2)) ((= n1 n2) (eq? c1 c2)))
+; So they combined as one rule.
+; (constrainto ((assign n1 c1) (assign n2 c2)) ((= n1 n2)))

--- a/examples/graph-coloring/gc.scm
+++ b/examples/graph-coloring/gc.scm
@@ -78,9 +78,11 @@
 ; % Top-down solver rules, this is an engineering hack, not stable model
 ; semantics. Other bottom-up solver won't produce the right answer.
 ; % Solving heuristic, node ordering.
+; :- assign(N1, C1), assign(N2, C2), N1 > N2.
 ; (constrainto ((assign n1 c1) (assign n2 c2)) ((> n1 n2)))
 
 ; % Remove duplicated answers in top-down query.
+; :- assign(N1, C1), assign(N2, C2), N1 = N2, C1 = C2.
 ; (constrainto ((assign n1 c1) (assign n2 c2)) ((= n1 n2) (eq? c1 c2)))
 ; So they combined as one rule.
 ; (constrainto ((assign n1 c1) (assign n2 c2)) ((= n1 n2)))

--- a/examples/n-queens/nq.scm
+++ b/examples/n-queens/nq.scm
@@ -44,15 +44,29 @@
  (conde
    [(num x) (num y) (noto (queen x y))]))
 
-; Top-down query optimization constraint, this is an engineering hack, not
-; stable model semantics. Other bottom-up solver won't produce the right answer.
-; (constrainto ((queen x y) (queen u v)) ((> x u)))
-
+; :- queen(X, Y), queen(U, V), X = U, Y != V.
 (constrainto ((queen x y) (queen u v)) ((= x u) (not (= y v))))
 
+; :- queen(X, Y), queen(U, V), Y = V, X != U.
 (constrainto ((queen x y) (queen u v)) ((= y v) (not (= x u))))
 
-(constrainto ((queen x y) (queen u v)) ((= (abs (- x u)) (abs (- y v)))))
+; :- queen(X, Y), queen(U, V), abs(X - U) = abs(Y - V), X != U, Y != V.
+(constrainto ((queen x y) (queen u v)) ((= (abs (- x u)) (abs (- y v))) (not (= x u)) (not (= y v))))
+
+; Solver specified rules (Not stable model semantics)
+; Top-down query optimization constraint, this is an engineering hack, not
+; stable model semantics. Other bottom-up solver won't produce the right answer.
+; :- queen(X, Y), queen(U, V), X > U.
+; (constrainto ((queen x y) (queen u v)) ((> x u)))
+
+; :- queen(X, Y), queen(U, V), X = U.
+; (constrainto ((queen x y) (queen u v)) ((= x u)))
+
+; :- queen(X, Y), queen(U, V), Y = V.
+; (constrainto ((queen x y) (queen u v)) ((= y v)))
+
+; :- queen(X, Y), queen(U, V), abs(X - U) = abs(Y - V).
+; (constrainto ((queen x y) (queen u v)) ((= (abs (- x u)) (abs (- y v)))))
 
 ; Adding a dummy head to predicate constraints, this also requires changes
 ; in resolution.

--- a/examples/n-queens/nq.scm
+++ b/examples/n-queens/nq.scm
@@ -44,11 +44,13 @@
  (conde
    [(num x) (num y) (noto (queen x y))]))
 
-(constrainto ((queen x y) (queen u v)) ((> x u)))
+; Top-down query optimization constraint, this is an engineering hack, not
+; stable model semantics. Other bottom-up solver won't produce the right answer.
+; (constrainto ((queen x y) (queen u v)) ((> x u)))
 
-(constrainto ((queen x y) (queen u v)) ((= x u)))
+(constrainto ((queen x y) (queen u v)) ((= x u) (not (= y v))))
 
-(constrainto ((queen x y) (queen u v)) ((= y v)))
+(constrainto ((queen x y) (queen u v)) ((= y v) (not (= x u))))
 
 (constrainto ((queen x y) (queen u v)) ((= (abs (- x u)) (abs (- y v)))))
 


### PR DESCRIPTION
Grumpy/picky PPDP' 24 reviewer 3 (issue #8) complained that the example code did not follow the stable model semantics. So, I updated the `nQueens` and `Graph Coloring` examples to follow the stable model semantics strictly. For the `Hamiltonian Cycle` example, the example code followed stable model semantics, and there was no applicable top-down solver specified non-stable model semantics `constrainto` rules.

I still believe some top-down solver-specified rules are helpful during the solving process but do not follow the stable model semantics. So, I will mention these in the paper.

P.S. There is nothing wrong with the underlying implementation and the overall ideas; it is just that the reviewer is judging our work by the example code.🙄