### PR TITLE
Dependency graph analysis

### DIFF
--- a/mk.scm
+++ b/mk.scm
@@ -157,7 +157,7 @@
             ; Performance optimization. If the input program is stratified, we 
             ; don't perform the additional non-monotonic resolution.
             ; [ToDo] This works at the syntax level only; add runtime level analysis later.
-            ; If the input program has constraint, it's a normal program.
+            ; If the input program has constraints, it's a normal program.
             (if (and (or (not (stratified?))
                          (constrained?))
                 (null? 

--- a/sk-tests/test-naf.scm
+++ b/sk-tests/test-naf.scm
@@ -158,8 +158,6 @@
     [(reachable x y) (noto (reducible y))]))
 
 ; test final-SCC problem run* to get all final-SCC.
-; [ToDo] Performance optimization.
-(reset-program)
 (test-check "testnaf.tex-10d"   
 (sort compare-element (remove-duplicates 
   (run* (q) (fresh (x y) (fullyReduce x y) (== q `(,x ,y))) )))

--- a/sk-tests/test-syntax.scm
+++ b/sk-tests/test-syntax.scm
@@ -121,3 +121,330 @@
            [(noto (== q 3)) (== q 4)])))
 
 `(4 1))
+
+
+;;; ==== Testing positive and negative twins ====
+(test-check "sktests.tex-positive-twin-eval-unification"
+(run* (q) (positive-twin (== 1 0)))
+
+`(_.0))
+
+(test-check "sktests.tex-positive-twin-expand-unification"
+(expand `(positive-twin (== 1 0)))
+
+'succeed)
+
+(test-check "sktests.tex-positive-twin-eval-succeed"
+(run* (q) (positive-twin succeed))
+
+`(_.0))
+
+(test-check "sktests.tex-positive-twin-expand-succeed"
+(expand `(positive-twin succeed))
+
+'succeed)
+
+(test-check "sktests.tex-positive-twin-eval-fail"
+(run* (q) (positive-twin fail))
+
+`())
+
+(test-check "sktests.tex-positive-twin-expand-fail"
+(expand `(positive-twin fail))
+
+'fail)
+
+;;; ==== Mock a p+ returns false ====
+(define (p+) fail)
+
+(test-check "sktests.tex-positive-twin-eval-goal"
+;;; It drops the parameter in (p 1 2), so we get (p), and it appends a "+" to p. 
+(run* (q) (positive-twin (p 1 2)))
+
+`())
+
+(test-check "sktests.tex-positive-twin-expand-goal"
+(syntax->datum ((top-level-syntax 'positive-twin) #'(positive-twin (p 1 2))))
+
+`(eval `(,(sym-append-str (car `(p 1 2)) "+"))))
+
+(test-check "sktests.tex-positive-twin-eval-expand-goal" 
+(run* (q)
+      (eval 
+        `,(syntax->datum ((top-level-syntax 'positive-twin) #'(positive-twin (p x y))))
+))
+
+`())
+
+(test-check "sktests.tex-positive-twin-eval-negation-goal"
+;;; It drops the parameter in (p 1 2), so we get (p), and it appends a "+" to p. 
+(run* (q) (positive-twin (noto (p 1 2))))
+
+`(_.0))
+
+(test-check "sktests.tex-positive-twin-expand-negation-goal"
+(syntax->datum ((top-level-syntax 'positive-twin) #'(positive-twin (noto (p 1 2)))))
+
+`(noto (positive-twin (p 1 2))))
+
+;;; ==== Integration testing (goals + negations + true/false) ====
+;;; ==== Mock a q+ r+ returns true ====
+(define (q+) succeed)
+(define (r+) succeed)
+
+(test-check "sktests.tex-positive-twin-eval-goals-1"
+(run* (q) (positive-twin (q 1 2) (r x y)))
+
+`(_.0))
+
+(test-check "sktests.tex-positive-twin-expand-goals-1"
+(syntax->datum ((top-level-syntax 'positive-twin) #'(positive-twin (q 1 2) (r x y))))
+
+`(fresh () (positive-twin (q 1 2)) (positive-twin (r x y))))
+
+(test-check "sktests.tex-positive-twin-eval-goals-2"
+(run* (q) (positive-twin (q 1 2) succeed))
+
+`(_.0))
+
+(test-check "sktests.tex-positive-twin-expand-goals-2"
+(syntax->datum ((top-level-syntax 'positive-twin) #'(positive-twin (q 1 2) fail)))
+
+`(fresh () (positive-twin (q 1 2)) (positive-twin fail)))
+
+(test-check "sktests.tex-positive-twin-eval-goals-3"
+(run* (q) (positive-twin (q 1 2) (noto fail)))
+
+`(_.0))
+
+(test-check "sktests.tex-positive-twin-expand-goals-3"
+(syntax->datum ((top-level-syntax 'positive-twin) #'(positive-twin (q 1 2) (noto (p x y)))))
+
+`(fresh () (positive-twin (q 1 2)) (positive-twin (noto (p x y)))))
+
+
+;;; ==== Complex formula (conde/fresh) ====
+;;; Special case, all unifications merge into one succeed.
+(test-check "sktests.tex-positive-twin-eval-conde-1"
+(run* (q) (positive-twin (conde [(== x 1)] [(== x 2)])))
+
+`(_.0))
+
+(test-check "sktests.tex-positive-twin-expand-conde-1"
+(syntax->datum ((top-level-syntax 'positive-twin) #'(positive-twin (conde [(== 
+  x 1)] [(== x 2)]))))
+
+'succeed)
+
+;;; Two succeeds from different conde clauses didnot merge into one.
+(test-check "sktests.tex-positive-twin-eval-conde-2"
+(run* (q) (positive-twin (conde [(== x 1)] [succeed])))
+
+`(_.0 _.0))
+
+(test-check "sktests.tex-positive-twin-expand-conde-2"
+(syntax->datum ((top-level-syntax 'positive-twin) #'(positive-twin (conde [(==
+  x 1)] [succeed]))))
+
+'(conde ((positive-twin (== x 1))) ((positive-twin succeed))))
+
+(test-check "sktests.tex-positive-twin-eval-conde-3"
+(run* (q) (positive-twin (conde [(q x 1)] [(r y 2) succeed])))
+
+`(_.0 _.0))
+
+(test-check "sktests.tex-positive-twin-expand-conde-3"
+(syntax->datum ((top-level-syntax 'positive-twin) #'(positive-twin (conde [(q 
+  x 1)] [(r y 2) succeed]))))
+
+'(conde
+  ((positive-twin (q x 1)))
+  ((positive-twin (r y 2)) (positive-twin succeed))))
+
+
+(test-check "sktests.tex-positive-twin-eval-fresh-1"
+(run* (q) (positive-twin (fresh (x y) (== x 1) (== y 2))))
+
+`(_.0))
+
+;;; Remove intermediate variables (x y) in fresh.
+(test-check "sktests.tex-positive-twin-expand-fresh-1"
+(syntax->datum ((top-level-syntax 'positive-twin) #'(positive-twin (fresh (x y)
+  (== x 1) (== y 2)))))
+
+'(fresh () (positive-twin (== x 1)) (positive-twin (== y 2))))
+
+(test-check "sktests.tex-positive-twin-eval-fresh-2"
+(run* (q) (positive-twin (fresh (x y) (q x) (r y))))
+
+`(_.0))
+
+;;; Remove intermediate variables (x y) in fresh.
+(test-check "sktests.tex-positive-twin-expand-fresh-2"
+(syntax->datum ((top-level-syntax 'positive-twin) #'(positive-twin (fresh (x y)
+  (q x) (r y)))))
+
+'(fresh () (positive-twin (q x)) (positive-twin (r y))))
+
+;;; ==== Negative twin is almost the same as the positive twin ====
+(test-check "sktests.tex-negative-twin-eval-unification"
+(run* (q) (negative-twin (== 1 0)))
+
+`(_.0))
+
+(test-check "sktests.tex-negative-twin-expand-unification"
+(expand `(negative-twin (== 1 0)))
+
+'succeed)
+
+(test-check "sktests.tex-negative-twin-eval-succeed"
+(run* (q) (negative-twin succeed))
+
+`(_.0))
+
+(test-check "sktests.tex-negative-twin-expand-succeed"
+(expand `(negative-twin succeed))
+
+'succeed)
+
+(test-check "sktests.tex-negative-twin-eval-fail"
+(run* (q) (negative-twin fail))
+
+`())
+
+(test-check "sktests.tex-negative-twin-expand-fail"
+(expand `(negative-twin fail))
+
+'fail)
+
+;;; ==== Mock a p- returns false ====
+(define (p-) fail)
+
+(test-check "sktests.tex-negative-twin-eval-goal"
+;;; It drops the parameter in (p 1 2), so we get (p), and it appends a "-" to p. 
+(run* (q) (negative-twin (p 1 2)))
+
+`())
+
+(test-check "sktests.tex-negative-twin-expand-goal"
+(syntax->datum ((top-level-syntax 'negative-twin) #'(negative-twin (p 1 2))))
+
+`(eval `(,(sym-append-str (car `(p 1 2)) "-"))))
+
+(test-check "sktests.tex-negative-twin-eval-expand-goal" 
+(run* (q)
+      (eval 
+        `,(syntax->datum ((top-level-syntax 'negative-twin) #'(negative-twin (p x y))))
+))
+
+`())
+
+(test-check "sktests.tex-negative-twin-eval-negation-goal"
+;;; It drops the parameter in (p 1 2), so we get (p), and it appends a "-" to p. 
+(run* (q) (negative-twin (noto (p 1 2))))
+
+`(_.0))
+
+(test-check "sktests.tex-negative-twin-expand-negation-goal"
+(syntax->datum ((top-level-syntax 'negative-twin) #'(negative-twin (noto (p 1 2)))))
+
+`(noto (negative-twin (p 1 2))))
+
+;;; ==== Integration testing (goals + negations + true/false) ====
+;;; ==== Mock a q- r- returns true ====
+(define (q-) succeed)
+(define (r-) succeed)
+
+(test-check "sktests.tex-negative-twin-eval-goals-1"
+(run* (q) (negative-twin (q 1 2) (r x y)))
+
+`(_.0))
+
+(test-check "sktests.tex-negative-twin-expand-goals-1"
+(syntax->datum ((top-level-syntax 'negative-twin) #'(negative-twin (q 1 2) (r x y))))
+
+`(fresh () (negative-twin (q 1 2)) (negative-twin (r x y))))
+
+(test-check "sktests.tex-negative-twin-eval-goals-2"
+(run* (q) (negative-twin (q 1 2) succeed))
+
+`(_.0))
+
+(test-check "sktests.tex-negative-twin-expand-goals-2"
+(syntax->datum ((top-level-syntax 'negative-twin) #'(negative-twin (q 1 2) fail)))
+
+`(fresh () (negative-twin (q 1 2)) (negative-twin fail)))
+
+(test-check "sktests.tex-negative-twin-eval-goals-3"
+(run* (q) (negative-twin (q 1 2) (noto fail)))
+
+`(_.0))
+
+(test-check "sktests.tex-negative-twin-expand-goals-3"
+(syntax->datum ((top-level-syntax 'negative-twin) #'(negative-twin (q 1 2) (noto (p x y)))))
+
+`(fresh () (negative-twin (q 1 2)) (negative-twin (noto (p x y)))))
+
+
+;;; ==== Complex formula (conde/fresh) ====
+;;; Special case, all unifications merge into one succeed.
+(test-check "sktests.tex-negative-twin-eval-conde-1"
+(run* (q) (negative-twin (conde [(== x 1)] [(== x 2)])))
+
+`(_.0))
+
+(test-check "sktests.tex-negative-twin-expand-conde-1"
+(syntax->datum ((top-level-syntax 'negative-twin) #'(negative-twin (conde [(== 
+  x 1)] [(== x 2)]))))
+
+'succeed)
+
+;;; Two succeeds from different conde clauses didnot merge into one.
+(test-check "sktests.tex-negative-twin-eval-conde-2"
+(run* (q) (negative-twin (conde [(== x 1)] [succeed])))
+
+`(_.0 _.0))
+
+(test-check "sktests.tex-negative-twin-expand-conde-2"
+(syntax->datum ((top-level-syntax 'negative-twin) #'(negative-twin (conde [(==
+  x 1)] [succeed]))))
+
+'(conde ((negative-twin (== x 1))) ((negative-twin succeed))))
+
+(test-check "sktests.tex-negative-twin-eval-conde-3"
+(run* (q) (negative-twin (conde [(q x 1)] [(r y 2) succeed])))
+
+`(_.0 _.0))
+
+(test-check "sktests.tex-negative-twin-expand-conde-3"
+(syntax->datum ((top-level-syntax 'negative-twin) #'(negative-twin (conde [(q 
+  x 1)] [(r y 2) succeed]))))
+
+'(conde
+  ((negative-twin (q x 1)))
+  ((negative-twin (r y 2)) (negative-twin succeed))))
+
+
+(test-check "sktests.tex-negative-twin-eval-fresh-1"
+(run* (q) (negative-twin (fresh (x y) (== x 1) (== y 2))))
+
+`(_.0))
+
+;;; Remove intermediate variables (x y) in fresh.
+(test-check "sktests.tex-negative-twin-expand-fresh-1"
+(syntax->datum ((top-level-syntax 'negative-twin) #'(negative-twin (fresh (x y)
+  (== x 1) (== y 2)))))
+
+'(fresh () (negative-twin (== x 1)) (negative-twin (== y 2))))
+
+(test-check "sktests.tex-negative-twin-eval-fresh-2"
+(run* (q) (negative-twin (fresh (x y) (q x) (r y))))
+
+`(_.0))
+
+;;; Remove intermediate variables (x y) in fresh.
+(test-check "sktests.tex-negative-twin-expand-fresh-2"
+(syntax->datum ((top-level-syntax 'negative-twin) #'(negative-twin (fresh (x y)
+  (q x) (r y)))))
+
+'(fresh () (negative-twin (q x)) (negative-twin (r y))))

--- a/sk.scm
+++ b/sk.scm
@@ -37,6 +37,75 @@
     	...))
     ((_ g) g)))
 
+;;; ==== self-aware program analysis twins (body) ====
+;;;
+;;; Syntax analysis to find stratified negations (noto + loop) in the program.
+;;; This is the first part, body translation, where the body of each clause is
+;;; rewritten. The head definition happens with `defineo`, where we assign
+;;; different semantics to the loops. In the body translation, we remove the
+;;; variables and append a suffix (+/-) to the goal's name to create twins.
+;;; 
+;;; Refer to the stratified negation definition for the justification.
+;;; A stratified negation means the negation (noto) and the loop in the program
+;;; do not mix. There are two levels of stratification: compilation time and
+;;; execution time. Compilation time means the stratification can be identified
+;;; by analyzing the input program with little effort, through simulation. 
+;;; We identify the compilation time here by removing the variables in the
+;;; program and creating two twins.
+;;; 
+;;; [ToDo] This works at the syntax level only; add runtime level analysis later.
+(define-syntax positive-twin
+  (syntax-rules (conde fresh noto == succeed fail)
+    ;;; [ToDo] It seems like the macro can not transform the program twice, or
+    ;;; we do not know how to do this properly yet. It is supposed to convert
+    ;;; unifications(==) to succeed, then merge all successes under the same
+    ;;; clause into one. So, we can reduce the number of successes during the
+    ;;; evaluation. We handle the special case, which contains all unifications.
+    ((_ (conde [(== a ...) ...] [(== b ...) ...] ...))
+        succeed)
+    ((_ (fresh (x ...) g g0 ...))
+        (fresh () (positive-twin g) (positive-twin g0) ...))
+    ((_ (conde [g g0 ...] [g1 g^ ...] ...))
+        (conde [(positive-twin g) (positive-twin g0) ...] [(positive-twin g1) (positive-twin g^) ...] ...))
+    ((_ (noto g))
+        (noto (positive-twin g)))
+    ;;; Here, unification is always replaced with success, no matter what
+    ;;; unification returns (success or failure). The failure at runtime will
+    ;;; cut off the loop. We assume the unification did not break the loop here,
+    ;;; so we are conservatively determined it is not stratified. If this false
+    ;;; positive case mistakenly interprets the program as non-stratified during
+    ;;; the syntax analysis, the runtime analysis will capture it. 
+    ((_ (== u v))
+        succeed)
+    ((_ succeed) succeed)
+    ((_ fail) fail)
+    ((_ (p ...))
+        (eval `(,(sym-append-str (car `(p ...)) "+"))))
+    ((_ g g0 ...) (fresh () (positive-twin g) (positive-twin g0) ...))
+    ))
+
+(define-syntax negative-twin
+  (syntax-rules (conde fresh noto == succeed fail)
+    ;;; Ditto positive-twin comment.
+    ((_ (conde [(== a ...) ...] [(== b ...) ...] ...))
+        succeed)
+    ((_ (fresh (x ...) g g0 ...))
+        (fresh () (negative-twin g) (negative-twin g0) ...))
+    ((_ (conde [g g0 ...] [g1 g^ ...] ...))
+        (conde [(negative-twin g) (negative-twin g0) ...] [(negative-twin g1) (negative-twin g^) ...] ...))
+    ((_ (noto g))
+        (noto (negative-twin g)))
+    ;;; Ditto positive-twin comment.
+    ((_ (== u v))
+        succeed)
+    ((_ succeed) succeed)
+    ((_ fail) fail)
+    ((_ (p ...))
+        (eval `(,(sym-append-str (car `(p ...)) "-"))))
+    ((_ g g0 ...) (fresh () (negative-twin g) (negative-twin g0) ...))
+    ))
+;;; ---- self-aware program analysis twins (body) ----
+
 ;;; ==== predicate constraint ====
 ;;; Compile emitters and verifier as our internal constraint rule representation.
 ;;; It is a key-value pair of <emitter, [emitters list, verifier]>.


### PR DESCRIPTION
This is the implementation of the [TFP 2025](https://trendsfp.github.io/2025/) paper, "Self-aware Program Analysis in stableKanren". The paper mentioned two issues in stableKanren on definite programs.

One of the issues came from [miniKanren 2023 workshop](https://icfp23.sigplan.org/home/minikanren-2023) reviewer feedback in issue #7, running stableKanren on a definite program with infinite models, and the implementation is merged in P/R #10

The other issue came from performance testing during earlier stableKanren implementation and was left as a to-do item (commit 4656ab8). Running nonmonotonic resolution on a stratified program slows down the stableKanren speed. A stratified program means the negation (noto) and the loop in the program do not mix. There are two levels of stratification: compilation time and execution time. Compilation time means the stratification can be identified by analyzing the input program with little effort, through simulation.

The main idea is to use stableKanren infrastructure to construct twins from the input program to achieve dependency graph analysis.

The implementation has two parts: body translation and head definition. In body translation, the body of each clause is rewritten. We remove the variables and append a suffix (+/-) to the goal's name to create twins. In the head definition, the semantics of each twin is provided. We assign different semantics to the loops. The positive twin returns true on a negative loop, but the negative twin returns false. Therefore, the twins produce the same results for stratified programs and produce different results for normal programs.