### PR TITLE
Add constant emitters support to CaVE

### DIFF
--- a/sk-tests/test-pcs.scm
+++ b/sk-tests/test-pcs.scm
@@ -35,14 +35,14 @@
 (constraint-compiler `((p0 x) (q1 y) (q0 z)) `(and (= x y) (= x z)))
 
 `((p0 (((p0 x) (q1 y) (q0 z)) (and (= x y) (= x z))))
-  (q1 (((q1 y) (q0 z) (p0 x)) (and (= x y) (= x z))))
+  (q1 (((q1 y) (p0 x) (q0 z)) (and (= x y) (= x z))))
   (q0 (((q0 z) (p0 x) (q1 y)) (and (= x y) (= x z))))))
 
 ; Three emitters and duplicated two
 (test-check "testpcx.tex-constraint-compiler-6"
 (constraint-compiler `((q1 y) (p0 x) (q1 z)) `(and (= x y) (= x z)))
 
-`((p0 (((p0 x) (q1 z) (q1 y)) (and (= x y) (= x z))))
+`((p0 (((p0 x) (q1 y) (q1 z)) (and (= x y) (= x z))))
   (q1 (((q1 y) (p0 x) (q1 z)) (and (= x y) (= x z))))))
 
 ;;; ==== Testing constraint-emitter ====
@@ -112,7 +112,7 @@
   (constrainto ((noto (q y)) (p x) (noto (q z))) ((= x y) (= x z)))
   constraint-rules))
 
-`((p0 (((p0 x) (q1 z) (q1 y)) (and (= x y) (= x z))))
+`((p0 (((p0 x) (q1 y) (q1 z)) (and (= x y) (= x z))))
   (q1 (((q1 y) (p0 x) (q1 z)) (and (= x y) (= x z))))))
 
 ;;; ==== Testing quote-symbol ====

--- a/sk-tests/test-pcs.scm
+++ b/sk-tests/test-pcs.scm
@@ -248,6 +248,32 @@
 
 `((lst str n s) ((list 'tomato 'potato) "world" 0 's)))
 
+;;; ==== Testing constraint-emitter-reorder ====
+; Untouched
+(test-check "testpcx.tex-constraint-emitter-reorder-1"
+(constraint-emitter-reorder 'apple `((assign 's sv) (assign 'e ev) (assign p pv)) `('e '1))
+
+`((assign 's sv) (assign 'e ev) (assign p pv)))
+
+; Matched variable
+(test-check "testpcx.tex-constraint-emitter-reorder-2"
+(constraint-emitter-reorder 'assign `((assign 's sv) (assign 'e ev) (assign p pv) (assign q qv)) `('a '1))
+
+`((assign p pv) (assign 's sv) (assign 'e ev) (assign q qv)))
+
+; Matched constant
+(test-check "testpcx.tex-constraint-emitter-reorder-3"
+(constraint-emitter-reorder 'assign `((assign 's sv) (assign 'e ev) (assign p pv) (assign q qv)) `('e '0))
+
+`((assign 'e ev) (assign 's sv) (assign p pv) (assign q qv)))
+
+; Variable before constant
+; To show the caller must ensure the constants are before the variables
+(test-check "testpcx.tex-constraint-emitter-reorder-4"
+(constraint-emitter-reorder 'assign `((apple 's sv) (assign p pv) (assign 'e ev) (assign q qv)) `('e '0))
+
+`((assign p pv) (apple 's sv) (assign 'e ev) (assign q qv)))
+
 ;;; ==== Integrated testing ====
 ;;; Integrate constraint-updater and constraint-checker
 (test-check "testpcx.tex-constraint-1"

--- a/sk-tests/test-pcs.scm
+++ b/sk-tests/test-pcs.scm
@@ -307,14 +307,14 @@
 
 ;;; ==== Integrated testing ====
 ;;; Integrate constraint-updater and constraint-checker
-(test-check "testpcx.tex-constraint-1"
+(test-check "testpcx.tex-variable-constraint-1"
 (constraint-checker 'p0 `(1)
   (constraint-updater 'q1 `(2) `((p0 (((p0 x) (q1 y)) (and (= x 1) (= y 2))))
                                (q1 (((q1 y) (p0 x)) (and (= x 1) (= y 2)))))))
 
 #t)
 
-(test-check "testpcx.tex-constraint-2"
+(test-check "testpcx.tex-variable-constraint-2"
 (constraint-checker 'p0 `(2)
   (constraint-updater 'q1 `(1) `((p0 (((p0 x) (q1 y)) (and (= x 1) (= y 2))))
                                (q1 (((q1 y) (p0 x)) (and (= x 1) (= y 2)))))))
@@ -325,21 +325,21 @@
 (reset-program)
 (constrainto ((p x) (noto (q y))) ((= x 1) (= y 2)))
 
-(test-check "testpcx.tex-constraint-3"
+(test-check "testpcx.tex-variable-constraint-3"
 (constraint-checker 'p0 `(1)
   (constraint-updater 'q1 `(2) `()))
 
 #t)
 
 ;;; Integrate constrainto, local constraint rules (L), constraint-updater, and constraint-checker
-(test-check "testpcx.tex-constraint-4"
+(test-check "testpcx.tex-variable-constraint-4"
 (constraint-checker 'p0 `(1)
   (constraint-updater 'q1 `(3) 
                     `((p0 (((p0 x)) ((lambda (y) (and (= x 1) (= y 2))) '2))))))
 
 #f)
 
-(test-check "testpcx.tex-constraint-5"
+(test-check "testpcx.tex-variable-constraint-5"
 (constraint-checker 'p0 `(1)
                     `((p0 (((p0 x)) ((lambda (y) (and (= x 1) (= y 2))) '2)))))
 
@@ -350,21 +350,21 @@
 (defineo (p x) (== x 1))
 
 ; Without killer constraint.
-(test-check "testpcx.tex-constraint-6a"
+(test-check "testpcx.tex-variable-constraint-6a"
 (run* (q) (p q))
 
 `(1))
 
 ; Add a constraint has no impact.
 (constrainto () (#f #t))
-(test-check "testpcx.tex-constraint-6b"
+(test-check "testpcx.tex-variable-constraint-6b"
 (run* (q) (p q))
 
 `(1))
 
 ; Add killer constraint.
 (constrainto () ((= 1 1)))
-(test-check "testpcx.tex-constraint-6c"
+(test-check "testpcx.tex-variable-constraint-6c"
 (run* (q) (p q))
 
 `(1))

--- a/sk-tests/test-pcs.scm
+++ b/sk-tests/test-pcs.scm
@@ -321,6 +321,35 @@
 
 #f)
 
+(test-check "testpcx.tex-constant-constraint-1"
+(constraint-checker 'p0 `(1 1)
+  (constraint-updater 'q1 `(1 2) `((p0 (((p0 1 x) (q1 1 y)) (and (= x 1) (= y 2))))
+                               (q1 (((p0 1 x) (q1 1 y)) (and (= x 1) (= y 2)))))))
+
+#t)
+
+(test-check "testpcx.tex-constant-constraint-2"
+(constraint-checker 'p0 `(2 2)
+  (constraint-updater 'q1 `(2 1) `((p0 (((p0 2 x) (q1 2 y)) (and (= x 1) (= y 2))))
+                               (q1 (((p0 2 x) (q1 2 y)) (and (= x 1) (= y 2)))))))
+
+#f)
+
+(test-check "testpcx.tex-variable-and-constant-constraint-1"
+(constraint-checker 'p0 `(1 1)
+  (constraint-updater 'q1 `(1 2) `((p0 (((p0 1 x) (q1 z y)) (and (= x 1) (= y 2))))
+                               (q1 (((p0 1 x) (q1 z y)) (and (= x 1) (= y 2)))))))
+
+#t)
+
+(test-check "testpcx.tex-variable-and-constant-constraint-2"
+(constraint-checker 'p0 `(2 2)
+  (constraint-updater 'q1 `(2 1) `((p0 (((p0 2 x) (q1 z y)) (and (= x 1) (= y 2))))
+                               (q1 (((p0 2 x) (q1 z y)) (and (= x 1) (= y 2)))))))
+
+#f)
+
+;;; [ToDo] Sort constant constraint before variable constraint in constrainto
 ;;; Integrate constrainto, constraint-updater, and constraint-checker
 (reset-program)
 (constrainto ((p x) (noto (q y))) ((= x 1) (= y 2)))
@@ -342,6 +371,28 @@
 (test-check "testpcx.tex-variable-constraint-5"
 (constraint-checker 'p0 `(1)
                     `((p0 (((p0 x)) ((lambda (y) (and (= x 1) (= y 2))) '2)))))
+
+#t)
+
+(reset-program)
+(constrainto [(p 1 2) (noto (q 2 1))] [])
+
+(test-check "testpcx.tex-constant-constraint-3"
+(constraint-checker 'p0 `(1 2)
+  (constraint-updater 'q1 `(2 1) `()))
+
+#t)
+
+(test-check "testpcx.tex-constant-constraint-4"
+(constraint-checker 'p0 `(1 1)
+  (constraint-updater 'q1 `(3 1) 
+                    `((p0 (((p0 1 x)) ((lambda (y) (and (= x 1) (= y 2))) '2))))))
+
+#f)
+
+(test-check "testpcx.tex-constant-constraint-5"
+(constraint-checker 'p0 `(2 1)
+                    `((p0 (((p0 2 x)) ((lambda (y) (and (= x 1) (= y 2))) '2)))))
 
 #t)
 

--- a/sk-tests/test-pcs.scm
+++ b/sk-tests/test-pcs.scm
@@ -227,6 +227,27 @@
 
 #t)
 
+;;; ==== Testing constraint-emitter-remove-constants ====
+; Empty list
+(test-check "testpcx.tex-constraint-emitter-remove-constants-1"
+(constraint-emitter-remove-constants `() `())
+
+`(() ()))
+
+; All constants (symbol, number, string, list)
+(test-check "testpcx.tex-constraint-emitter-remove-constants-2"
+; The values does not matter, see assumption in the comment
+(constraint-emitter-remove-constants `('r 1 "hello" (list 'foo 'bar)) `('s 0 "world" (list 'tomato 'potato)))
+
+`(() ()))
+
+; Reverse ordering (symbol, number, string, list)
+(test-check "testpcx.tex-constraint-emitter-remove-constants-3"
+; The ordering does not matter as long as they matched the values
+(constraint-emitter-remove-constants `(s n str lst) `('s 0 "world" (list 'tomato 'potato)))
+
+`((lst str n s) ((list 'tomato 'potato) "world" 0 's)))
+
 ;;; ==== Integrated testing ====
 ;;; Integrate constraint-updater and constraint-checker
 (test-check "testpcx.tex-constraint-1"

--- a/sk-tests/test-pcs.scm
+++ b/sk-tests/test-pcs.scm
@@ -206,6 +206,27 @@
 
 `((p0 (((p0 x)) ((lambda (y) (and (= x 1) (= y 2))) '2)))))
 
+;;; ==== Testing constraint-emitter-matched-constants? ====
+; No constants in parameters
+(test-check "testpcx.tex-constraint-emitter-matched-constants-1"
+(constraint-emitter-matched-constants? `(a b) `('0 'hello))
+
+#t)
+
+; No matched constants
+(test-check "testpcx.tex-constraint-emitter-matched-constants-2"
+(constraint-emitter-matched-constants? `(a 0) `('a '1))
+
+#f)
+
+; Matched constants (symbol, number, string, list)
+(test-check "testpcx.tex-constraint-emitter-matched-constants-3"
+(constraint-emitter-matched-constants?
+  `(a   0 'a b         "world" (list 'tomato 'potato))
+  `('a '0 'a '"hello" '"world" (list 'tomato 'potato)))
+
+#t)
+
 ;;; ==== Integrated testing ====
 ;;; Integrate constraint-updater and constraint-checker
 (test-check "testpcx.tex-constraint-1"

--- a/sk-tests/test-pcs.scm
+++ b/sk-tests/test-pcs.scm
@@ -274,6 +274,37 @@
 
 `((assign p pv) (apple 's sv) (assign 'e ev) (assign q qv)))
 
+;;; ==== Testing constraint-emitter-filter ====
+; Unmatched name
+(test-check "testpcx.tex-constraint-emitter-filter-1"
+(constraint-emitter-filter 'apple `((assign 's sv) (assign p pv) (assign 'e ev) (assign q qv)) `('e '0))
+
+#f)
+
+; Unmatched constants (no variables)
+(test-check "testpcx.tex-constraint-emitter-filter-2"
+(constraint-emitter-filter 'assign `((assign 's sv) (assign 'p pv) (assign 'e ev) (assign 'q qv)) `('r '0))
+
+#f)
+
+; Matched variables (unmatched constants)
+(test-check "testpcx.tex-constraint-emitter-filter-3"
+(constraint-emitter-filter 'assign `((assign 's sv) (assign p pv) (assign 'e ev) (assign q qv)) `('r '0))
+
+#t)
+
+; Matched constants (no variables)
+(test-check "testpcx.tex-constraint-emitter-filter-4"
+(constraint-emitter-filter 'assign `((assign 's sv) (assign 'p pv) (assign 'e ev) (assign 'q qv)) `('e '0))
+
+#t)
+
+; Matched constants and variables (only the first match will be used later)
+(test-check "testpcx.tex-constraint-emitter-filter-5"
+(constraint-emitter-filter 'assign `((assign 's sv) (assign p pv) (assign 'e ev) (assign q qv)) `('e '0))
+
+#t)
+
 ;;; ==== Integrated testing ====
 ;;; Integrate constraint-updater and constraint-checker
 (test-check "testpcx.tex-constraint-1"

--- a/sk-tests/test-utils.scm
+++ b/sk-tests/test-utils.scm
@@ -34,6 +34,47 @@
 
 `(3 1 2))
 
+;;; ==== Testing move-to-first ====
+; Empty list
+(test-check "testutil.tex-move-to-first-1"
+(move-to-first 6 `() =)
+
+`())
+
+; Element not in list
+(test-check "testutil.tex-move-to-first-2"
+(move-to-first 7 `(1 2 3 4 5 6) =)
+
+`(1 2 3 4 5 6))
+
+; First element in the list
+(test-check "testutil.tex-move-to-first-3"
+(move-to-first 1 `(1 2 3 4 5 6) =)
+
+`(1 2 3 4 5 6))
+
+; Element in the list
+(test-check "testutil.tex-move-to-first-4"
+(move-to-first 3 `(1 2 3 4 5 6) =)
+
+`(3 1 2 4 5 6))
+
+; Last element in the list
+(test-check "testutil.tex-move-to-first-5"
+(move-to-first 6 `(1 2 3 4 5 6) =)
+
+`(6 1 2 3 4 5))
+
+; Difference between rotate and move
+(test-check "testutil.tex-move-to-first-and-rotate-to-first-1"
+(equal? (move-to-first 6 `(1 2 3 4 5 6) =) (rotate-to-first 6 `(1 2 3 4 5 6) =))
+
+#t)
+
+(test-check "testutil.tex-move-to-first-and-rotate-to-first-2"
+(equal? (move-to-first 3 `(1 2 3 4 5 6) =) (rotate-to-first 3 `(1 2 3 4 5 6) =))
+
+#f)
 
 ;;; ==== Testing sym-append-str ====
 ; Empty string

--- a/sk.scm
+++ b/sk.scm
@@ -129,7 +129,7 @@
   (remove-duplicates 
   (map (lambda (emitter)
         `(,(car emitter) 
-         (,(rotate-to-first emitter emitters
+         (,(move-to-first emitter emitters
               (lambda (l r) (eq? (car l) (car r))))
           ,expr)))
   emitters)))

--- a/sk.scm
+++ b/sk.scm
@@ -279,7 +279,7 @@
   (lambdag@(n cfs c : S P L)
     ; At this point, all arguments have a substitution.
     (let* ([key (map (lambda (arg)
-                     (walk arg S)) argv)]
+                     (walk* arg S)) argv)]
            [result (element-of-set? (list name key) P)]
            [emitter (sym-append-str name
                 (number->string (modulo n 2)))])

--- a/utils.scm
+++ b/utils.scm
@@ -29,7 +29,7 @@
 
 ;;; Rotate element e to the first of the list.
 ; O(n) complexity.
-; If there is more than one element matched, only move to the first match.
+; If there is more than one element matched, only rotate to the first match.
 (define (rotate-to-first e l cmp)
   (define (iterate lhs rhs)
     (cond
@@ -37,6 +37,17 @@
       [(cmp e (car rhs)) (append lhs (reverse rhs))]
       (else (iterate (cons (car rhs) lhs) (cdr rhs)))))
   (reverse (iterate `() l)))
+
+;;; Move element e to the first of the list.
+; O(n) complexity.
+; If there is more than one element matched, only move the first match.
+(define (move-to-first e l cmp)
+  (define (iterate lhs rhs)
+    (cond
+      [(null? rhs) lhs]
+      [(cmp e (car rhs)) (cons (car rhs) (append lhs (cdr rhs)))]
+      (else (iterate (append lhs (list (car rhs))) (cdr rhs)))))
+  (iterate `() l))
 
 ;;; Find bounded variables from a substitution.
 ; O(n) complexity.


### PR DESCRIPTION
As described in #13, there is a need for handling constant emitters in a constraint.

We categorize an emitter in CaVE into two types: variable emitter (supported by the previous CaVE implementation #6) and constant emitter (added support in this implementation). The emitter still **emits once**, either variable or constant. We do not support mixing variable and constant emitters at this moment, as more research work is needed.

To support constant emitters, we add `constraint-emitter-matched-constants?` to match the constant in the emitter to the values (9d79ad9), `constraint-emitter-remove-constants` to remove the constant in the emitter and the corresponding values (ea11063), `constraint-emitter-reorder` to reorder the emitter in the emitters list based on the corresponding values (5427386), `constraint-emitter-filter` to filter out the emitters list that have only variables or matched constants based on the emitter name (870fb41), and we use `constraint-emitter-filter` to filter out matching variable and constant emitters (5c472c8). Then in `constraint-propagator`, we use `constraint-emitter-reorder` to move the proper emitter to the first of the emitter list, `constraint-emitter-remove-constants` to remove any constants in the parameter list and the corresponding values.
